### PR TITLE
Feat#10 누락된 아카이브 기능 복구

### DIFF
--- a/dailyq/src/main/java/com/knuissant/dailyq/config/ObjectMapperConfig.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/config/ObjectMapperConfig.java
@@ -1,0 +1,15 @@
+package com.knuissant.dailyq.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ObjectMapperConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper().registerModule(new JavaTimeModule());
+    }
+}

--- a/dailyq/src/main/java/com/knuissant/dailyq/controller/AnswerController.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/controller/AnswerController.java
@@ -1,7 +1,19 @@
 package com.knuissant.dailyq.controller;
 
+import com.knuissant.dailyq.dto.AnswerArchiveUpdateRequest;
+import com.knuissant.dailyq.dto.AnswerArchiveUpdateResponse;
+import com.knuissant.dailyq.dto.AnswerDetailResponse;
+import com.knuissant.dailyq.dto.AnswerListResponse;
+import com.knuissant.dailyq.dto.AnswerSearchConditionRequest;
+import com.knuissant.dailyq.exception.BusinessException;
+import com.knuissant.dailyq.exception.ErrorCode;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -26,13 +38,65 @@ public class AnswerController {
 
     private final AnswerService answerService;
 
+    @GetMapping
+    public ResponseEntity<AnswerListResponse.CursorResult<AnswerListResponse.Summary>> getAnswers(
+
+            @RequestParam Long userId,
+
+            @ModelAttribute AnswerSearchConditionRequest condition,
+
+            @RequestParam(required = false) String cursor,
+
+            @RequestParam(defaultValue = "10") int limit) {
+
+        //정렬 조건 단일 파라미터 검증
+        long filterCount = Stream.of(
+                condition.sortOrder(),
+                condition.date(),
+                condition.jobId(),
+                condition.questionType(),
+                condition.level(),
+                condition.starred()
+        ).filter(Objects::nonNull).count();
+
+        Optional.of(filterCount)
+                .filter(count -> count <= 1)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MULTIPLE_FILTER_NOT_ALLOWED));
+
+        AnswerListResponse.CursorResult<AnswerListResponse.Summary> result = answerService.getArchives(
+                userId, condition, cursor, limit);
+        return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/{answerId}")
+    public ResponseEntity<AnswerDetailResponse> getAnswerDetail(
+            @PathVariable Long answerId) {
+
+        AnswerDetailResponse result = answerService.getAnswerDetail(answerId);
+
+        return ResponseEntity.ok(result);
+    }
+
+    @PatchMapping("/{answerId}")
+    public ResponseEntity<AnswerArchiveUpdateResponse> updateAnswerDetail(
+            @PathVariable Long answerId,
+            @RequestBody AnswerArchiveUpdateRequest request) {
+
+        Long userId = 1L; // 임시
+
+        AnswerArchiveUpdateResponse responseDto = answerService.updateAnswer(userId, answerId,
+                request);
+
+        return ResponseEntity.ok(responseDto);
+    }
+
     // userId 추후 제거
     @PostMapping
     public ResponseEntity<AnswerCreateResponse> submitAnswer(
             @RequestParam("user_id") Long userId,
             @Valid @RequestBody AnswerCreateRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED)
-                             .body(answerService.createAnswerAndFeedback(request, userId));
+                .body(answerService.createAnswerAndFeedback(request, userId));
     }
 
     @PatchMapping("/{answerId}/level")

--- a/dailyq/src/main/java/com/knuissant/dailyq/dto/AnswerArchiveUpdateRequest.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/dto/AnswerArchiveUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.knuissant.dailyq.dto;
+
+
+public record AnswerArchiveUpdateRequest(
+        String memo,
+
+        Boolean starred,
+
+        Integer level
+) {
+
+}

--- a/dailyq/src/main/java/com/knuissant/dailyq/dto/AnswerArchiveUpdateResponse.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/dto/AnswerArchiveUpdateResponse.java
@@ -1,0 +1,16 @@
+package com.knuissant.dailyq.dto;
+
+import com.knuissant.dailyq.domain.answers.Answer;
+
+public record AnswerArchiveUpdateResponse (
+        Boolean starred,
+
+        Integer level,
+
+        String memo
+) {
+    public static AnswerArchiveUpdateResponse from (Answer answer) {
+        return new AnswerArchiveUpdateResponse(answer.getStarred(), answer.getLevel(),
+                answer.getMemo());
+    }
+}

--- a/dailyq/src/main/java/com/knuissant/dailyq/dto/AnswerDetailResponse.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/dto/AnswerDetailResponse.java
@@ -1,0 +1,55 @@
+package com.knuissant.dailyq.dto;
+
+import com.knuissant.dailyq.domain.answers.Answer;
+import com.knuissant.dailyq.domain.feedbacks.Feedback;
+import com.knuissant.dailyq.domain.feedbacks.FeedbackStatus;
+import com.knuissant.dailyq.domain.questions.Question;
+import com.knuissant.dailyq.domain.questions.QuestionType;
+import java.time.LocalDateTime;
+
+public record AnswerDetailResponse(
+        Long answerId,
+        QuestionSummary question,
+        String answerText,
+        Integer level,
+        Boolean starred,
+        LocalDateTime answeredTime,
+        FeedbackDetail feedback
+) {
+
+    public record QuestionSummary(Long questionId, QuestionType questionType, String questionText
+    ) {
+
+        public static QuestionSummary from(Question question) {
+            return new QuestionSummary(
+                    question.getId(),
+                    question.getQuestionType(),
+                    question.getQuestionText()
+            );
+        }
+    }
+
+    public record FeedbackDetail(FeedbackStatus status, String feedbackText, LocalDateTime updatedAt
+    ) {
+
+        public static FeedbackDetail from(Feedback feedback) {
+            return new FeedbackDetail(
+                    feedback.getStatus(),
+                    feedback.getContent(),
+                    feedback.getUpdatedAt()
+            );
+        }
+    }
+
+    public static AnswerDetailResponse of(Answer answer, Feedback feedback) {
+        return new AnswerDetailResponse(
+                answer.getId(),
+                QuestionSummary.from(answer.getQuestion()),
+                answer.getAnswerText(),
+                answer.getLevel(),
+                answer.getStarred(),
+                answer.getAnsweredTime(),
+                (feedback != null) ? FeedbackDetail.from(feedback) : null
+        );
+    }
+}

--- a/dailyq/src/main/java/com/knuissant/dailyq/dto/AnswerListResponse.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/dto/AnswerListResponse.java
@@ -1,0 +1,45 @@
+package com.knuissant.dailyq.dto;
+
+import com.knuissant.dailyq.domain.answers.Answer;
+import com.knuissant.dailyq.domain.questions.FlowPhase;
+import com.knuissant.dailyq.domain.questions.QuestionType;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record AnswerListResponse(List<Summary> summaries) {
+
+    public record Summary(
+            Long answerId,
+            Long questionId,
+            String questionText,
+            QuestionType questionType,
+            FlowPhase flowPhase,
+            Integer level,
+            Boolean starred,
+            LocalDateTime answeredTime
+    ) {
+
+        public static Summary from(Answer answer) {
+            return new Summary(
+                    answer.getId(),
+                    answer.getQuestion().getId(),
+                    answer.getQuestion().getQuestionText(),
+                    answer.getQuestion().getQuestionType(),
+                    null, // flow_phase는 FE와 협의 필요
+                    answer.getLevel(),
+                    answer.getStarred(),
+                    answer.getAnsweredTime()
+            );
+        }
+    }
+
+    public record CursorResult<T>(
+            List<T> items,
+
+            String nextCursor,
+
+            boolean hasNext
+    ) {
+
+    }
+}

--- a/dailyq/src/main/java/com/knuissant/dailyq/dto/AnswerSearchConditionRequest.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/dto/AnswerSearchConditionRequest.java
@@ -1,0 +1,21 @@
+package com.knuissant.dailyq.dto;
+
+import com.knuissant.dailyq.domain.questions.QuestionType;
+import java.time.LocalDate;
+
+public record AnswerSearchConditionRequest(
+
+        LocalDate date,
+
+        Long jobId,
+
+        QuestionType questionType,
+
+        Boolean starred,
+
+        Integer level,
+
+        String sortOrder
+) {
+
+}

--- a/dailyq/src/main/java/com/knuissant/dailyq/repository/AnswerRepository.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/repository/AnswerRepository.java
@@ -2,10 +2,12 @@ package com.knuissant.dailyq.repository;
 
 import com.knuissant.dailyq.domain.answers.Answer;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface AnswerRepository extends JpaRepository<Answer, Long> {
+public interface AnswerRepository extends JpaRepository<Answer, Long>,
+        JpaSpecificationExecutor<Answer> {
 
     @Query(value = "SELECT COUNT(*) FROM answers WHERE user_id = :userId AND DATE(answered_time) = CURDATE()", nativeQuery = true)
     long countTodayByUserId(@Param("userId") Long userId);

--- a/dailyq/src/main/java/com/knuissant/dailyq/repository/FeedbackRepository.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/repository/FeedbackRepository.java
@@ -1,10 +1,12 @@
 package com.knuissant.dailyq.repository;
 
 import com.knuissant.dailyq.domain.feedbacks.Feedback;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
 
+    Optional<Feedback> findByAnswerId(Long answerId);
 }

--- a/dailyq/src/main/java/com/knuissant/dailyq/service/AnswerService.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/service/AnswerService.java
@@ -1,5 +1,26 @@
 package com.knuissant.dailyq.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.knuissant.dailyq.domain.jobs.Job;
+import com.knuissant.dailyq.dto.AnswerArchiveUpdateRequest;
+import com.knuissant.dailyq.dto.AnswerArchiveUpdateResponse;
+import com.knuissant.dailyq.dto.AnswerDetailResponse;
+import com.knuissant.dailyq.dto.AnswerListResponse.CursorResult;
+import com.knuissant.dailyq.dto.AnswerListResponse.Summary;
+import com.knuissant.dailyq.dto.AnswerSearchConditionRequest;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.JoinType;
+import jakarta.persistence.criteria.Predicate;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,6 +50,69 @@ public class AnswerService {
     private final FeedbackRepository feedbackRepository;
     private final QuestionRepository questionRepository;
     private final UserRepository userRepository;
+    private final ObjectMapper objectMapper;
+
+    //API 스펙과 무관하며(오로지,내부사용) 재사용 가능성이 없다고 생각하여 따로 DTO를 만들지 않았습니다.
+    private record CursorRequest(LocalDateTime answeredTime, Long id) {
+
+    }
+
+    @Transactional(readOnly = true)
+    public CursorResult<Summary> getArchives(Long userId, AnswerSearchConditionRequest condition,
+            String cursor, int limit) {
+        //커서 파싱
+        CursorRequest cursorRequest = parseCursor(cursor);
+
+        String actualSortOrder = (condition.sortOrder() != null) ? condition.sortOrder() : "DESC";
+        boolean isDesc = !"ASC".equalsIgnoreCase(actualSortOrder);
+
+        // answeredTime + answerId를 통한 유니크 순서 보장
+        Sort.Direction direction = isDesc ? Sort.Direction.DESC : Sort.Direction.ASC;
+        Sort sort = Sort.by(direction, "answeredTime").and(Sort.by(direction, "id"));
+
+        Pageable pageable = PageRequest.of(0, limit + 1, sort);
+
+        Specification<Answer> spec = createSpecification(userId, condition, cursorRequest, isDesc);
+
+        List<Answer> answers = answerRepository.findAll(spec, pageable).getContent();
+        return convertToCursorResult(answers, limit);
+    }
+
+    @Transactional
+    public AnswerArchiveUpdateResponse updateAnswer(Long userId, Long answerId,
+            AnswerArchiveUpdateRequest request) {
+
+        Answer answer = answerRepository.findById(answerId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ANSWER_NOT_FOUND));
+        // 인가
+        if (!answer.getUser().getId().equals(userId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN_ACCESS);
+        }
+
+        if (request.memo() != null) {
+            answer.updateMemo(request.memo());
+        }
+
+        if (request.starred() != null) {
+            answer.updateStarred(request.starred());
+        }
+
+        if (request.level() != null) {
+            answer.updateLevel(request.level());
+        }
+
+        return AnswerArchiveUpdateResponse.from(answer);
+    }
+
+    @Transactional(readOnly = true)
+    public AnswerDetailResponse getAnswerDetail(Long answerId) {
+
+        Answer answer = answerRepository.findById(answerId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ANSWER_NOT_FOUND));
+        Feedback feedback = feedbackRepository.findByAnswerId(answerId).orElse(null);
+        return AnswerDetailResponse.of(answer, feedback);
+
+    }
 
     @Transactional
     public AnswerCreateResponse createAnswerAndFeedback(AnswerCreateRequest request, Long userId) {
@@ -59,5 +143,92 @@ public class AnswerService {
         answer.updateLevel(request.level());
 
         return new AnswerLevelUpdateResponse(answer.getId(), answer.getLevel());
+    }
+
+    private Specification<Answer> createSpecification(Long userId,
+            AnswerSearchConditionRequest condition, AnswerService.CursorRequest cursorRequest,
+            boolean isDesc) {
+        return (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+
+            predicates.add(cb.equal(root.get("user").get("id"), userId));
+
+            if (cursorRequest != null) {
+                Predicate timePredicate = isDesc ?
+                        cb.lessThan(root.get("answeredTime"), cursorRequest.answeredTime()) :
+                        cb.greaterThan(root.get("answeredTime"), cursorRequest.answeredTime());
+
+                Predicate tieBreaker = cb.and(
+                        cb.equal(root.get("answeredTime"), cursorRequest.answeredTime()),
+                        isDesc ? cb.lessThan(root.get("id"), cursorRequest.id())
+                                : cb.greaterThan(root.get("id"), cursorRequest.id())
+                );
+                predicates.add(cb.or(timePredicate, tieBreaker));
+            }
+
+            Join<Answer, Question> questionJoin = null;
+
+            if (condition.date() != null) {
+                predicates.add(cb.equal(root.get("answeredDate"), condition.date()));
+            }
+            if (condition.jobId() != null) {
+                if (questionJoin == null) {
+                    questionJoin = root.join("question", JoinType.INNER);
+                }
+                Join<Question, Job> jobsJoin = questionJoin.join("jobs", JoinType.INNER);
+                predicates.add(cb.equal(jobsJoin.get("id"), condition.jobId()));
+            }
+            if (condition.questionType() != null) {
+                if (questionJoin == null) {
+                    questionJoin = root.join("question", JoinType.INNER);
+                }
+                predicates.add(
+                        cb.equal(questionJoin.get("questionType"), condition.questionType()));
+            }
+            if (condition.starred() != null) {
+                predicates.add(cb.equal(root.get("starred"), condition.starred()));
+            }
+            if (condition.level() != null) {
+                predicates.add(cb.equal(root.get("level"), condition.level()));
+            }
+
+            return cb.and(predicates.toArray(new Predicate[0]));
+        };
+    }
+
+    private CursorResult<Summary> convertToCursorResult(List<Answer> answers, int limit) {
+        boolean hasNext = answers.size() > limit;
+        List<Answer> content = hasNext ? answers.subList(0, limit) : answers;
+
+        List<Summary> summaries = content.stream()
+                .map(Summary::from)
+                .toList();
+
+        String nextCursor = hasNext ? createCursor(content.get(content.size() - 1)) : null;
+
+        return new CursorResult<>(summaries, nextCursor, hasNext);
+    }
+
+    // 커서 생성/파싱 로직
+    private String createCursor(Answer answer) {
+        try {
+            CursorRequest cursorData = new CursorRequest(answer.getAnsweredTime(), answer.getId());
+            String json = objectMapper.writeValueAsString(cursorData);
+            return Base64.getEncoder().encodeToString(json.getBytes());
+        } catch (JsonProcessingException e) {
+            throw new BusinessException(ErrorCode.CURSOR_GENERATION_FAILED);
+        }
+    }
+
+    private CursorRequest parseCursor(String cursorStr) {
+        if (cursorStr == null || cursorStr.isBlank()) {
+            return null;
+        }
+        try {
+            byte[] decodedBytes = Base64.getDecoder().decode(cursorStr);
+            return objectMapper.readValue(new String(decodedBytes), CursorRequest.class);
+        } catch (IOException | IllegalArgumentException e) {
+            throw new BusinessException(ErrorCode.INVALID_CURSOR);
+        }
     }
 }


### PR DESCRIPTION

# 🔄 Pull Request

## 📝 변경 사항 요약
<!-- 이 PR에서 변경된 내용을 간단하게 요약해주세요 -->
- 아카이브 조회 API (GET /api/answers)
- 아카이브 상세 조회 API (GET /api/answers/{answerId})
- 답변 수정 API (PATCH /api/answers/{answerId})
## 🎯 관련 이슈
<!-- 이 PR이 해결하는 이슈가 있다면 링크해주세요 -->
Closes #13 

## 🔍 변경 사항 상세
<!-- 변경된 내용을 자세히 설명해주세요 -->
- 아카이브 페이지에서 ``answeredTime``과 ``id``를 조합한 커서 기반 페이지네이션을 ``JPA Specification``을 활용하여 적용
    - 단일 필터링 기능을 추가하여, 날짜, 직군, 질문 유형, 난이도, 즐겨찾기 중 하나의 조건으로 필터링 가능 
    - ``JPA Specification``을 활용하지 않고 구현하려 했으나 코드 가독성이 매우 낮아 도입
- 사용자가 선택한 답변의 상세 내용을 조회하는 API를 구현
- 상세 페이지에서 ``memo`` 또는 ``starred`` 또는 ``level``중 각각 요청하거나, 모두 동시에 요청하는 경우를 모두 처리
- 다른 사용자의 답변을 수정할 수 없도록 인가 로직 구현
### ✨ 추가된 기능
위와 동일

### 🐛 수정된 버그
- 

### 🔧 개선된 부분
- 

### 📚 문서 변경
- 

## 🧪 테스트
<!-- 어떤 테스트를 수행했는지 설명해주세요 -->
- [ ] 단위 테스트 통과
- [ ] 통합 테스트 통과
- [x] 수동 테스트 완료
- [ ] 브라우저 호환성 확인

## 📸 스크린샷
<!-- 필요하다면 스크린샷을 첨부해주세요 -->

## 🔍 코드 리뷰 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 불필요한 코드나 주석을 제거했습니다
- [x] 적절한 에러 처리를 추가했습니다
- [ ] 로깅을 적절히 추가했습니다
- [x] 보안 관련 이슈가 없습니다

## 📋 추가 정보
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->
- 상세페이지 옵션 FLOW 부분에 대해 FE,BE와 논의 필요

## ✅ 체크리스트
- [x] 커밋 메시지가 명확하고 일관성 있습니다
- [ ] 관련 문서를 업데이트했습니다
- [x] 새로운 의존성을 추가하지 않았습니다
- [x] 기존 기능을 깨뜨리지 않습니다
- [x] 팀원들과 논의했습니다

## 🚀 배포 관련
- [ ] 데이터베이스 마이그레이션이 필요합니다
- [ ] 환경 변수 변경이 필요합니다
- [ ] 새로운 설정이 필요합니다
- [ ] 기타:
