### PR TITLE
Feat#42 단방향 라이벌 기능(라이벌 신청, 신청 수락, 신청 거절, 라이벌 신청 목록 조회) 구현

### DIFF
--- a/dailyq/src/main/java/com/knuissant/dailyq/controller/RivalController.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/controller/RivalController.java
@@ -2,8 +2,10 @@ package com.knuissant.dailyq.controller;
 
 import java.util.List;
 
+import org.apache.coyote.Response;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -53,5 +55,15 @@ public class RivalController {
         RivalResponse response = rivalService.acceptRivalRequest(senderId, receiverId);
 
         return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/requests/reject/{senderId}")
+    public ResponseEntity<Void> rejectRivalRequest(@PathVariable Long senderId) {
+
+        Long receiverId = 2L; //임시
+
+        rivalService.rejectRivalRequest(senderId, receiverId);
+
+        return ResponseEntity.noContent().build();
     }
 }

--- a/dailyq/src/main/java/com/knuissant/dailyq/controller/RivalController.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/controller/RivalController.java
@@ -1,0 +1,32 @@
+package com.knuissant.dailyq.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+import com.knuissant.dailyq.dto.rivals.RivalResponse;
+import com.knuissant.dailyq.service.RivalService;
+
+@RestController
+@RequestMapping("/api/rivals")
+@RequiredArgsConstructor
+public class RivalController {
+
+    private final RivalService rivalService;
+
+    @PostMapping("/{targetUserId}")
+    public ResponseEntity<RivalResponse> sendRivalRequest(
+            @PathVariable Long targetUserId) {
+
+        Long senderId = 1L; // 임시
+
+        RivalResponse rivalResponseDto = rivalService.sendRivalRequest(senderId, targetUserId);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(rivalResponseDto);
+    }
+}

--- a/dailyq/src/main/java/com/knuissant/dailyq/controller/RivalController.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/controller/RivalController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -42,5 +43,15 @@ public class RivalController {
         List<ReceivedRivalRequest> responses = rivalService.getReceivedRequests(receiverId);
 
         return ResponseEntity.ok(responses);
+    }
+
+    @PatchMapping("/requests/accept/{senderId}")
+    public ResponseEntity<RivalResponse> acceptRivalRequest(@PathVariable Long senderId) {
+
+        Long receiverId = 2L; // 임시
+
+        RivalResponse response = rivalService.acceptRivalRequest(senderId, receiverId);
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/dailyq/src/main/java/com/knuissant/dailyq/controller/RivalController.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/controller/RivalController.java
@@ -1,7 +1,10 @@
 package com.knuissant.dailyq.controller;
 
+import java.util.List;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -9,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
 
+import com.knuissant.dailyq.dto.rivals.ReceivedRivalRequest;
 import com.knuissant.dailyq.dto.rivals.RivalResponse;
 import com.knuissant.dailyq.service.RivalService;
 
@@ -28,5 +32,15 @@ public class RivalController {
         RivalResponse rivalResponseDto = rivalService.sendRivalRequest(senderId, targetUserId);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(rivalResponseDto);
+    }
+
+    @GetMapping("/requests/received")
+    public ResponseEntity<List<ReceivedRivalRequest>> getReceivedRequests() {
+
+        Long receiverId = 2L; // 임시
+
+        List<ReceivedRivalRequest> responses = rivalService.getReceivedRequests(receiverId);
+
+        return ResponseEntity.ok(responses);
     }
 }

--- a/dailyq/src/main/java/com/knuissant/dailyq/controller/RivalController.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/controller/RivalController.java
@@ -2,7 +2,6 @@ package com.knuissant.dailyq.controller;
 
 import java.util.List;
 
-import org.apache.coyote.Response;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;

--- a/dailyq/src/main/java/com/knuissant/dailyq/domain/rivals/Rival.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/domain/rivals/Rival.java
@@ -20,6 +20,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import com.knuissant.dailyq.domain.users.User;
+import com.knuissant.dailyq.exception.BusinessException;
+import com.knuissant.dailyq.exception.ErrorCode;
 
 @Getter
 @Builder
@@ -60,4 +62,20 @@ public class Rival {
                 .status(RivalStatus.WAITING)
                 .build();
     }
+
+    public static Rival createAccepted(User sender, User receiver) {
+        return Rival.builder()
+                .sender(sender)
+                .receiver(receiver)
+                .status(RivalStatus.ACCEPTED)
+                .build();
+    }
+
+    public void accept() {
+        if (this.status != RivalStatus.WAITING) {
+            throw new BusinessException(ErrorCode.RIVAL_REQUEST_ALREADY_EXIST);
+        }
+        this.status = RivalStatus.ACCEPTED;
+    }
+
 }

--- a/dailyq/src/main/java/com/knuissant/dailyq/domain/rivals/Rival.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/domain/rivals/Rival.java
@@ -1,0 +1,63 @@
+package com.knuissant.dailyq.domain.rivals;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import com.knuissant.dailyq.domain.users.User;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Entity
+@Table(name = "rivals",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uq_rivals_pair",
+                        columnNames = {"sender_id", "receiver_id"}
+                )
+        }
+)
+public class Rival {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "rival_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "sender_id", nullable = false)
+    private User sender;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "receiver_id", nullable = false)
+    private User receiver;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 10)
+    private RivalStatus status;
+
+    public static Rival create(User sender, User receiver) {
+        return Rival.builder()
+                .sender(sender)
+                .receiver(receiver)
+                .status(RivalStatus.WAITING)
+                .build();
+    }
+}

--- a/dailyq/src/main/java/com/knuissant/dailyq/domain/rivals/RivalStatus.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/domain/rivals/RivalStatus.java
@@ -1,0 +1,7 @@
+package com.knuissant.dailyq.domain.rivals;
+
+public enum RivalStatus {
+    WAITING,
+    ACCEPTED,
+    REJECTED
+}

--- a/dailyq/src/main/java/com/knuissant/dailyq/dto/rivals/ReceivedRivalRequest.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/dto/rivals/ReceivedRivalRequest.java
@@ -1,0 +1,17 @@
+package com.knuissant.dailyq.dto.rivals;
+
+import com.knuissant.dailyq.domain.rivals.Rival;
+
+public record ReceivedRivalRequest(
+        Long rivalId,
+        Long requesterId,
+        String requesterName
+) {
+    public static ReceivedRivalRequest from(Rival rival) {
+        return new ReceivedRivalRequest(
+                rival.getId(),
+                rival.getSender().getId(),
+                rival.getSender().getName()
+        );
+    }
+}

--- a/dailyq/src/main/java/com/knuissant/dailyq/dto/rivals/RivalResponse.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/dto/rivals/RivalResponse.java
@@ -1,0 +1,25 @@
+package com.knuissant.dailyq.dto.rivals;
+
+import com.knuissant.dailyq.domain.rivals.Rival;
+import com.knuissant.dailyq.domain.rivals.RivalStatus;
+
+public record RivalResponse (
+        Long rivalId,
+        Long senderId,
+        String senderName,
+        Long receiverId,
+        String receiverName,
+        RivalStatus status
+) {
+
+    public static RivalResponse from(Rival rival) {
+        return new RivalResponse(
+                rival.getId(),
+                rival.getSender().getId(),
+                rival.getSender().getName(),
+                rival.getReceiver().getId(),
+                rival.getReceiver().getName(),
+                rival.getStatus()
+        );
+    }
+}

--- a/dailyq/src/main/java/com/knuissant/dailyq/exception/ErrorCode.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/exception/ErrorCode.java
@@ -24,7 +24,7 @@ public enum ErrorCode {
   // etc 4xx
   FORBIDDEN_ACCESS("FORBIDDEN_ACCESS", "리소스에 접근할 권한이 없습니다.", HttpStatus.FORBIDDEN),
   DAILY_LIMIT_REACHED("DAILY_LIMIT_REACHED", "오늘 가능한 질문을 모두 소진했습니다.", HttpStatus.TOO_MANY_REQUESTS),
-
+  RIVAL_REQUEST_ALREADY_EXIST("RIVAL_REQUEST_ALREADY_EXIST","이미 라이벌 요청이 존재합니다.",HttpStatus.CONFLICT),
   //5xx System Errors
   INTERNAL_SERVER_ERROR("INTERNAL_SERVER_ERROR", "서버 내부에 에러가 발생하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
   CURSOR_GENERATION_FAILED("CURSOR_GENERATION_FAILED", "커서 생성에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),

--- a/dailyq/src/main/java/com/knuissant/dailyq/exception/ErrorCode.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/exception/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
   NO_QUESTION_AVAILABLE("NO_QUESTION_AVAILABLE", "조건에 맞는 질문이 없습니다.", HttpStatus.NOT_FOUND),
   OCCUPATION_NOT_FOUND("OCCUPATION_NOT_FOUND", "직군을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
   JOB_NOT_FOUND("JOB_NOT_FOUND", "직업을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+  RIVAL_REQUEST_NOT_FOUND("RIVAL_REQUEST_NOT_FOUND","라이벌 요청을 찾을 수 없습니다.",HttpStatus.NOT_FOUND),
   // etc 4xx
   FORBIDDEN_ACCESS("FORBIDDEN_ACCESS", "리소스에 접근할 권한이 없습니다.", HttpStatus.FORBIDDEN),
   DAILY_LIMIT_REACHED("DAILY_LIMIT_REACHED", "오늘 가능한 질문을 모두 소진했습니다.", HttpStatus.TOO_MANY_REQUESTS),

--- a/dailyq/src/main/java/com/knuissant/dailyq/repository/RivalRepository.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/repository/RivalRepository.java
@@ -1,0 +1,19 @@
+package com.knuissant.dailyq.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.knuissant.dailyq.domain.rivals.Rival;
+import com.knuissant.dailyq.domain.rivals.RivalStatus;
+
+public interface RivalRepository extends JpaRepository<Rival, Long> {
+
+    // WAITING 상태인 즉 사용자가 받은 라이벌 신청 목록 조회
+    List<Rival> findByReceiverIdAndStatus(Long receiverId, RivalStatus status);
+
+    // 사용자간 라이벌 관계 조회
+    Optional<Rival> findBySenderIdAndReceiverId(Long senderId, Long receiverId);
+
+}

--- a/dailyq/src/main/java/com/knuissant/dailyq/repository/RivalRepository.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/repository/RivalRepository.java
@@ -15,4 +15,6 @@ public interface RivalRepository extends JpaRepository<Rival, Long> {
 
     boolean existsBySenderIdAndReceiverId(Long senderId, Long receiverId);
 
+    Optional<Rival> findBySenderIdAndReceiverId(Long senderId, Long receiverId);
+
 }

--- a/dailyq/src/main/java/com/knuissant/dailyq/repository/RivalRepository.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/repository/RivalRepository.java
@@ -13,7 +13,6 @@ public interface RivalRepository extends JpaRepository<Rival, Long> {
     // WAITING 상태인 즉 사용자가 받은 라이벌 신청 목록 조회
     List<Rival> findByReceiverIdAndStatus(Long receiverId, RivalStatus status);
 
-    // 사용자간 라이벌 관계 조회
-    Optional<Rival> findBySenderIdAndReceiverId(Long senderId, Long receiverId);
+    boolean existsBySenderIdAndReceiverId(Long senderId, Long receiverId);
 
 }

--- a/dailyq/src/main/java/com/knuissant/dailyq/service/RivalService.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/service/RivalService.java
@@ -53,16 +53,20 @@ public class RivalService {
     }
 
     public RivalResponse acceptRivalRequest(Long senderId, Long receiverId) {
-        Rival rivalRequest = rivalRepository.findBySenderIdAndReceiverId(senderId, receiverId)
-                .filter(r -> r.getStatus() == RivalStatus.WAITING)
-                .orElseThrow(
-                        () -> new BusinessException(ErrorCode.RIVAL_REQUEST_NOT_FOUND, senderId,
-                                receiverId));
+
+        Rival rivalRequest = findWaitingRivalRequest(senderId, receiverId);
 
         rivalRequest.accept();
         createMutualRival(receiverId, senderId);
 
         return RivalResponse.from(rivalRequest);
+    }
+
+    public void rejectRivalRequest(Long senderId, Long receiverId) {
+
+        Rival rivalRequest = findWaitingRivalRequest(senderId, receiverId);
+
+        rivalRepository.delete(rivalRequest);
     }
 
     private User findUserById(Long userId) {
@@ -94,5 +98,13 @@ public class RivalService {
 
             rivalRepository.save(mutualRival);
         }
+    }
+
+    private Rival findWaitingRivalRequest(Long senderId, Long receiverId) {
+        return rivalRepository.findBySenderIdAndReceiverId(senderId, receiverId)
+                .filter(r -> r.getStatus() == RivalStatus.WAITING)
+                .orElseThrow(
+                        () -> new BusinessException(ErrorCode.RIVAL_REQUEST_NOT_FOUND, senderId,
+                                receiverId));
     }
 }

--- a/dailyq/src/main/java/com/knuissant/dailyq/service/RivalService.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/service/RivalService.java
@@ -56,8 +56,7 @@ public class RivalService {
 
         Rival rivalRequest = findWaitingRivalRequest(senderId, receiverId);
 
-        rivalRequest.accept();
-        createMutualRival(receiverId, senderId);
+        rivalRequest.accept(); //단방향
 
         return RivalResponse.from(rivalRequest);
     }
@@ -81,22 +80,6 @@ public class RivalService {
         if (exists) {
             throw new BusinessException(ErrorCode.RIVAL_REQUEST_ALREADY_EXIST, senderId,
                     receiverId);
-        }
-    }
-
-    private void createMutualRival(Long senderId, Long receiverId) {
-
-        boolean mutualRivalExists = rivalRepository
-                .existsBySenderIdAndReceiverId(senderId, receiverId);
-
-        if (!mutualRivalExists) {
-
-            User receiver = findUserById(receiverId);
-            User sender = findUserById(senderId);
-
-            Rival mutualRival = Rival.createAccepted(sender, receiver);
-
-            rivalRepository.save(mutualRival);
         }
     }
 

--- a/dailyq/src/main/java/com/knuissant/dailyq/service/RivalService.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/service/RivalService.java
@@ -1,0 +1,51 @@
+package com.knuissant.dailyq.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+import com.knuissant.dailyq.domain.rivals.Rival;
+import com.knuissant.dailyq.domain.users.User;
+import com.knuissant.dailyq.dto.rivals.RivalResponse;
+import com.knuissant.dailyq.exception.BusinessException;
+import com.knuissant.dailyq.exception.ErrorCode;
+import com.knuissant.dailyq.repository.RivalRepository;
+import com.knuissant.dailyq.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class RivalService {
+
+    private final RivalRepository rivalRepository;
+    private final UserRepository userRepository;
+
+    public RivalResponse sendRivalRequest(Long senderId, Long receiverId) {
+
+        User sender = findUserById(senderId);
+        User receiver = findUserById(receiverId);
+
+        validateRivalRequestNotExists(senderId, receiverId);
+
+        Rival rivalRequest = Rival.create(sender, receiver);
+        Rival savedRival = rivalRepository.save(rivalRequest);
+
+        return RivalResponse.from(savedRival);
+    }
+
+    private User findUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND, userId));
+    }
+
+    private void validateRivalRequestNotExists(Long senderId, Long receiverId) {
+        boolean exists = rivalRepository.existsBySenderIdAndReceiverId(senderId, receiverId) ||
+                rivalRepository.existsBySenderIdAndReceiverId(receiverId, senderId);
+
+        if (exists) {
+            throw new BusinessException(ErrorCode.RIVAL_REQUEST_ALREADY_EXIST, senderId,
+                    receiverId);
+        }
+    }
+}

--- a/dailyq/src/main/java/com/knuissant/dailyq/service/RivalService.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/service/RivalService.java
@@ -1,12 +1,17 @@
 package com.knuissant.dailyq.service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
 import com.knuissant.dailyq.domain.rivals.Rival;
+import com.knuissant.dailyq.domain.rivals.RivalStatus;
 import com.knuissant.dailyq.domain.users.User;
+import com.knuissant.dailyq.dto.rivals.ReceivedRivalRequest;
 import com.knuissant.dailyq.dto.rivals.RivalResponse;
 import com.knuissant.dailyq.exception.BusinessException;
 import com.knuissant.dailyq.exception.ErrorCode;
@@ -32,6 +37,19 @@ public class RivalService {
         Rival savedRival = rivalRepository.save(rivalRequest);
 
         return RivalResponse.from(savedRival);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ReceivedRivalRequest> getReceivedRequests(Long receiverId) {
+
+        if (!userRepository.existsById(receiverId)) {
+            throw new BusinessException(ErrorCode.USER_NOT_FOUND, receiverId);
+        }
+
+        return rivalRepository.findByReceiverIdAndStatus(receiverId, RivalStatus.WAITING)
+                .stream()
+                .map(ReceivedRivalRequest::from)
+                .collect(Collectors.toList());
     }
 
     private User findUserById(Long userId) {


### PR DESCRIPTION
# 🔄 Pull Request

## 📝 변경 사항
<!-- 변경된 내용을 자세히 설명해주세요 -->
응원하기 기능을 넣지 않는 것으로 확정하여 단방향 라이벌 관계가 형성될 수 있도록 구성
- ``POST`` /api/rivals/{targetUserId} (라이벌 신청)
- ``GET`` /api/rivals/reqeusts/received (누가 나에게 라이벌 신청했는지 목록 조회)
- ``PATCH`` /api/rivals/requests/accept/senderId} (라이벌 신청 수락)
- ``DELETE`` /api/rivals/requests/reject/{senderId} (라이벌 신청 거절)

## 🎯 관련 이슈
<!-- 이 PR이 해결하는 이슈가 있다면 링크해주세요 -->
Closes #42 

## 📸 스크린샷
<!-- 필요하다면 스크린샷을 첨부해주세요 -->
POSTMAN
- userId 1가 2에게 라이벌신청
<img width="1170" height="621" alt="image" src="https://github.com/user-attachments/assets/69af4383-b4f9-4d32-b134-3975040f67de" />

- 라이벌 요청 조회
<img width="497" height="360" alt="image" src="https://github.com/user-attachments/assets/e3ddb75c-f0c7-45b7-9ae4-1720e4ab9d4d" />

- 라이벌 요청 수락
<img width="535" height="392" alt="image" src="https://github.com/user-attachments/assets/9edd81ce-77eb-4fa0-9e48-1000cdbe1e96" />

## 📋 추가 정보
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->
- 기본 기능과 달리 완벽하게 협의된 사항이 없어 많은 생각이 들었습니다. 
- 라이벌 신청할 유저 검색 api와 라이벌 신청할 상대 페이지 및 마이페이지ver2?) -> 마이페이지랑 분리되는 개념 
까지 넣으면 PR에 너무 많은 코드가 들어갈 것같아 우선 기본적인 플로우부터 PR 올렸습니다.
- ``GET`` URL이 수정되어야할 것 같은데 FE와 협의없이 단독으로 구현한 사항이라 얘기해봐야할 것 같습니다.
-  현재 라이벌 신청 거절시 단순히 ``DELETE``로 요청 삭제가 되도록 구현되어 있는데
    - 거절 시 상태 REJECTED로 UPDATE + N일간 재요청 금지로 구현하는 것이 더 나을지 고민이 됩니다.
- auth 구현 시 수정 필요