### PR TITLE
Fix#50 answeredDate 삭제 반영(answerService) 및 answered_time -> created_at 필드명 변경 최종 반영

### DIFF
--- a/dailyq/src/main/java/com/knuissant/dailyq/domain/answers/Answer.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/domain/answers/Answer.java
@@ -28,8 +28,8 @@ import com.knuissant.dailyq.domain.users.User;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Entity
 @Table(name = "answers", indexes = {
-        @Index(name = "idx_answers_user_time", columnList = "user_id, answered_time DESC"),
-        @Index(name = "idx_answers_q_time", columnList = "question_id, answered_time DESC")
+        @Index(name = "idx_answers_user_time", columnList = "user_id, created_at DESC"),
+        @Index(name = "idx_answers_q_time", columnList = "question_id, created_at DESC")
 })
 public class Answer {
 

--- a/dailyq/src/main/java/com/knuissant/dailyq/repository/AnswerRepository.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/repository/AnswerRepository.java
@@ -10,7 +10,7 @@ import com.knuissant.dailyq.domain.answers.Answer;
 public interface AnswerRepository extends JpaRepository<Answer, Long>,
         JpaSpecificationExecutor<Answer> {
 
-    @Query(value = "SELECT COUNT(*) FROM answers WHERE user_id = :userId AND answered_time >= CURDATE() AND answered_time < DATE_ADD(CURDATE(), INTERVAL 1 DAY)", nativeQuery = true)
+    @Query(value = "SELECT COUNT(*) FROM answers WHERE user_id = :userId AND created_at >= CURDATE() AND created_at < DATE_ADD(CURDATE(), INTERVAL 1 DAY)", nativeQuery = true)
     long countTodayByUserId(@Param("userId") Long userId);
 }
 

--- a/dailyq/src/main/java/com/knuissant/dailyq/service/AnswerService.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/service/AnswerService.java
@@ -2,6 +2,7 @@ package com.knuissant.dailyq.service;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
@@ -173,7 +174,10 @@ public class AnswerService {
             Join<Answer, Question> questionJoin = null;
 
             if (condition.date() != null) {
-                predicates.add(cb.equal(root.get("answeredDate"), condition.date()));
+                LocalDateTime startOfDay = condition.date().atStartOfDay();
+                LocalDateTime endOfDay = condition.date().atTime(LocalTime.MAX);
+
+                predicates.add(cb.between(root.get("createdAt"), startOfDay, endOfDay));
             }
             if (condition.jobId() != null) {
                 if (questionJoin == null) {


### PR DESCRIPTION
# 🔄 Pull Request

## 📝 변경 사항
<!-- 변경된 내용을 자세히 설명해주세요 -->
- answeredTime 뿐만 아니라 answered_time이 여전히 사용되고 있어 수정
- answerService에서 삭제된 answeredDate가 사용되는 로직 수정

## 🎯 관련 이슈
<!-- 이 PR이 해결하는 이슈가 있다면 링크해주세요 -->
Closes #50 