### PR TITLE
Refactor#55 Feedback Service의 트랜잭션 내부에서 외부 API 호출 문제 해결

### DIFF
--- a/dailyq/src/main/java/com/knuissant/dailyq/external/gpt/GptClient.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/external/gpt/GptClient.java
@@ -29,7 +29,7 @@ public class GptClient {
             maxAttempts = 3,
             backoff = @Backoff(delay = 2000, multiplier = 2)
     )
-    public FeedbackResponse getFeedback(String systemPrompt, String userPrompt) {
+    public FeedbackResponse call(String systemPrompt, String userPrompt) {
 
         try {
             return chatClient.prompt()

--- a/dailyq/src/main/java/com/knuissant/dailyq/repository/FeedbackRepository.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/repository/FeedbackRepository.java
@@ -3,6 +3,8 @@ package com.knuissant.dailyq.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.knuissant.dailyq.domain.feedbacks.Feedback;
@@ -11,4 +13,7 @@ import com.knuissant.dailyq.domain.feedbacks.Feedback;
 public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
 
     Optional<Feedback> findByAnswerId(Long answerId);
+
+    @Query("SELECT f FROM Feedback f JOIN FETCH f.answer a JOIN FETCH a.question q WHERE f.id = :id")
+    Optional<Feedback> findByIdWithDetails(@Param("id") Long id);
 }

--- a/dailyq/src/main/java/com/knuissant/dailyq/repository/FeedbackRepository.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/repository/FeedbackRepository.java
@@ -2,9 +2,8 @@ package com.knuissant.dailyq.repository;
 
 import java.util.Optional;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.knuissant.dailyq.domain.feedbacks.Feedback;
@@ -14,6 +13,6 @@ public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
 
     Optional<Feedback> findByAnswerId(Long answerId);
 
-    @Query("SELECT f FROM Feedback f JOIN FETCH f.answer a JOIN FETCH a.question q WHERE f.id = :id")
-    Optional<Feedback> findByIdWithDetails(@Param("id") Long id);
+    @EntityGraph(attributePaths = {"answer", "answer.question"})
+    Optional<Feedback> findWithDetailsById(Long id);
 }

--- a/dailyq/src/main/java/com/knuissant/dailyq/service/FeedbackService.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/service/FeedbackService.java
@@ -24,7 +24,7 @@ public class FeedbackService {
 
     public FeedbackResponse generateFeedback(Long feedbackId) {
 
-        Feedback feedback = feedbackRepository.findById(feedbackId)
+        Feedback feedback = feedbackRepository.findByIdWithDetails(feedbackId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.FEEDBACK_NOT_FOUND));
         String question = feedback.getAnswer().getQuestion().getQuestionText();
         String answer = feedback.getAnswer().getAnswerText();

--- a/dailyq/src/main/java/com/knuissant/dailyq/service/FeedbackService.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/service/FeedbackService.java
@@ -26,7 +26,7 @@ public class FeedbackService {
 
     public FeedbackResponse generateFeedback(Long feedbackId) {
 
-        Feedback feedback = feedbackRepository.findByIdWithDetails(feedbackId)
+        Feedback feedback = feedbackRepository.findWithDetailsById(feedbackId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.FEEDBACK_NOT_FOUND));
         String question = feedback.getAnswer().getQuestion().getQuestionText();
         String answer = feedback.getAnswer().getAnswerText();

--- a/dailyq/src/main/java/com/knuissant/dailyq/service/FeedbackService.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/service/FeedbackService.java
@@ -34,7 +34,7 @@ public class FeedbackService {
 
         long startTime = System.currentTimeMillis();
         try {
-            FeedbackResponse feedbackResponse = gptClient.getFeedback(systemPrompt, userPrompt);
+            FeedbackResponse feedbackResponse = gptClient.call(systemPrompt, userPrompt);
             long latencyMs = System.currentTimeMillis() - startTime;
 
             feedbackUpdateService.updateFeedbackSuccess(feedbackId, feedbackResponse, latencyMs);

--- a/dailyq/src/main/java/com/knuissant/dailyq/service/FeedbackService.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/service/FeedbackService.java
@@ -3,6 +3,7 @@ package com.knuissant.dailyq.service;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import com.knuissant.dailyq.domain.feedbacks.Feedback;
 import com.knuissant.dailyq.dto.feedbacks.FeedbackResponse;
@@ -13,6 +14,7 @@ import com.knuissant.dailyq.external.gpt.PromptManager;
 import com.knuissant.dailyq.external.gpt.PromptType;
 import com.knuissant.dailyq.repository.FeedbackRepository;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class FeedbackService {
@@ -41,7 +43,12 @@ public class FeedbackService {
             return feedbackResponse;
 
         } catch (Exception e) {
-            feedbackUpdateService.updateFeedbackFailure(feedbackId);
+            try {
+                feedbackUpdateService.updateFeedbackFailure(feedbackId);
+            } catch (Exception failureUpdateEx) {
+                log.error("Filed to update status to FAILED for feedbackId {}, Original error: {}",
+                        feedbackId, e.getMessage());
+            }
             throw e;
         }
     }

--- a/dailyq/src/main/java/com/knuissant/dailyq/service/FeedbackUpdateService.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/service/FeedbackUpdateService.java
@@ -1,0 +1,46 @@
+package com.knuissant.dailyq.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.knuissant.dailyq.domain.feedbacks.Feedback;
+import com.knuissant.dailyq.domain.feedbacks.FeedbackStatus;
+import com.knuissant.dailyq.dto.feedbacks.FeedbackResponse;
+import com.knuissant.dailyq.exception.BusinessException;
+import com.knuissant.dailyq.exception.ErrorCode;
+import com.knuissant.dailyq.exception.InfraException;
+import com.knuissant.dailyq.repository.FeedbackRepository;
+
+@Service
+@RequiredArgsConstructor
+public class FeedbackUpdateService {
+
+    private final FeedbackRepository feedbackRepository;
+    private final ObjectMapper objectMapper;
+
+    @Transactional
+    public void updateFeedbackSuccess(Long feedbackId, FeedbackResponse feedbackResponse, long latencyMs) {
+        Feedback feedback = feedbackRepository.findById(feedbackId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.FEEDBACK_NOT_FOUND));
+        try {
+            feedback.updateContent(objectMapper.writeValueAsString(feedbackResponse));
+            feedback.updateLatencyMs(latencyMs);
+            feedback.updateStatus(FeedbackStatus.DONE);
+        } catch (JsonProcessingException e) {
+            throw new InfraException(ErrorCode.JSON_PROCESSING_ERROR);
+        }
+    }
+
+    @Transactional
+    public void updateFeedbackFailure(Long feedbackId) {
+        Feedback feedback = feedbackRepository.findById(feedbackId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.FEEDBACK_NOT_FOUND));
+        feedback.updateStatus(FeedbackStatus.FAILED);
+    }
+
+}


### PR DESCRIPTION
# 🔄 Pull Request

## 📝 변경 사항
<!-- 변경된 내용을 자세히 설명해주세요 -->
- 기존 `Feedback Service`에서 트랜잭션이 필요한 업데이트 부분만 `FeedbackUpdateService`로 분리하여 트랜잭션 적용
- `FeedbackService`에서 조회와 GPT 호출을 담당한 후 `FeedbackUpdateService`를 호출하도록 하여 트랜잭션 범위를 외부 API 호출 이후로 축소
- `FeedbackRepository`에 Fetch Join을 적용한 `findByIdWithDetails()` 추가하여 피드백 조회 시 발생하는 지연 로딩 문제 해결
- GPT API 호출 실패 혹은 `DONE` 상태 업데이트 실패 후, `FAILED` 상태 업데이트마저 실패하는 경우엔 엔티티의 상태가 `PENDING`으로 남는 문제 발생 => '실패를 기록하는 것을 실패'를 처리하기 위해 로그를 남겨 문제를 추적 가능하도록 함
- 추가로, `GptClient`의 `getFeedback()` -> `call()`로 변경

## 🎯 관련 이슈
<!-- 이 PR이 해결하는 이슈가 있다면 링크해주세요 -->
Closes #55

## 📸 스크린샷
<!-- 필요하다면 스크린샷을 첨부해주세요 -->

## 📋 추가 정보
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->