### PR TITLE
Refactor#78 AnswerService에서 Pending 상태의 Feedback 생성 로직 분리

### DIFF
--- a/dailyq/src/main/java/com/knuissant/dailyq/service/AnswerService.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/service/AnswerService.java
@@ -19,10 +19,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
-
 import com.knuissant.dailyq.domain.answers.Answer;
 import com.knuissant.dailyq.domain.feedbacks.Feedback;
-import com.knuissant.dailyq.domain.feedbacks.FeedbackStatus;
 import com.knuissant.dailyq.domain.jobs.Job;
 import com.knuissant.dailyq.domain.questions.Question;
 import com.knuissant.dailyq.domain.users.User;
@@ -51,6 +49,7 @@ public class AnswerService {
     private final FeedbackRepository feedbackRepository;
     private final QuestionRepository questionRepository;
     private final UserRepository userRepository;
+    private final FeedbackService feedbackService;
 
     //API 스펙과 무관하며(오로지,내부사용) 재사용 가능성이 없다고 생각하여 따로 DTO를 만들지 않았습니다.
     private record CursorRequest(LocalDateTime createdAt, Long id) {
@@ -129,8 +128,7 @@ public class AnswerService {
         Answer answer = Answer.create(user, question, request.answerText());
         Answer savedAnswer = answerRepository.save(answer);
 
-        Feedback feedback = Feedback.create(savedAnswer, FeedbackStatus.PENDING);
-        Feedback savedFeedback = feedbackRepository.save(feedback);
+        Feedback savedFeedback = feedbackService.createPendingFeedback(savedAnswer);
 
         return AnswerCreateResponse.from(savedAnswer, savedFeedback);
     }

--- a/dailyq/src/main/java/com/knuissant/dailyq/service/FeedbackService.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/service/FeedbackService.java
@@ -1,11 +1,14 @@
 package com.knuissant.dailyq.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import com.knuissant.dailyq.domain.answers.Answer;
 import com.knuissant.dailyq.domain.feedbacks.Feedback;
+import com.knuissant.dailyq.domain.feedbacks.FeedbackStatus;
 import com.knuissant.dailyq.dto.feedbacks.FeedbackResponse;
 import com.knuissant.dailyq.exception.BusinessException;
 import com.knuissant.dailyq.exception.ErrorCode;
@@ -23,6 +26,13 @@ public class FeedbackService {
     private final FeedbackRepository feedbackRepository;
     private final PromptManager promptManager;
     private final FeedbackUpdateService feedbackUpdateService;
+
+    @Transactional
+    public Feedback createPendingFeedback(Answer answer) {
+
+        Feedback feedback = Feedback.create(answer, FeedbackStatus.PENDING);
+        return feedbackRepository.save(feedback);
+    }
 
     public FeedbackResponse generateFeedback(Long feedbackId) {
 


### PR DESCRIPTION
# 🔄 Pull Request

## 📝 변경 사항
<!-- 변경된 내용을 자세히 설명해주세요 -->
- 변경 전: `AnswerService`의 `submitAnswer`에서 `Pending` 상태의 `Feedback` 생성
- 변경 후: `AnswerService`의 `submitAnswer`에서 `FeedbackService`의 `createPendingFeedback`을 호출, `createPendingFeedback`에서 `Feedback` 생성

## 🎯 관련 이슈
<!-- 이 PR이 해결하는 이슈가 있다면 링크해주세요 -->
Closes #78

## 📸 스크린샷
<!-- 필요하다면 스크린샷을 첨부해주세요 -->

## 📋 추가 정보
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->
- 이슈 #78 에 두 가지 대안 중 서비스 직접 호출 방식을 사용했는데 혹시 결정 근거가 납득이 안 된다거나 다른 의견 있으시면 말해주세요.. 저도 혼자 생각해보고 판단해본 거라 다른 의견 언제든 환영입니다!