### PR TITLE
fix : JPQL CAST를 Native Query인 DATE()로 변경

### DIFF
--- a/dailyq/src/main/java/com/knuissant/dailyq/repository/AnswerRepository.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/repository/AnswerRepository.java
@@ -21,11 +21,16 @@ public interface AnswerRepository extends JpaRepository<Answer, Long>,
 
     long countByUserId(Long userId);
 
-    @Query("SELECT new com.knuissant.dailyq.dto.rivals.RivalProfileResponse.DailySolveCount(CAST(a.createdAt AS LocalDate), COUNT(a)) " +
-            "FROM Answer a " +
-            "WHERE a.user.id = :userId AND a.createdAt >= :startDate " +
-            "GROUP BY CAST(a.createdAt AS LocalDate)")
-    List<RivalProfileResponse.DailySolveCount> findDailySolveCountsByUserId(@Param("userId") Long userId,
+    @Query(value = """
+            SELECT DATE(a.created_at) as date, COUNT(*) as count 
+            FROM answers a 
+            WHERE a.user_id = :userId 
+              AND a.created_at >= :startDate 
+            GROUP BY DATE(a.created_at)
+            ORDER BY date DESC
+            """, nativeQuery = true)
+    List<Object[]> findDailySolveCountsByUserId(
+            @Param("userId") Long userId,
             @Param("startDate") LocalDateTime startDate);
 }
 

--- a/dailyq/src/main/java/com/knuissant/dailyq/service/RivalService.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/service/RivalService.java
@@ -1,5 +1,6 @@
 package com.knuissant.dailyq.service;
 
+import java.sql.Date;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -69,8 +70,15 @@ public class RivalService {
         long totalAnswerCount = answerRepository.countByUserId(userId);
 
         LocalDateTime forOneYear = LocalDateTime.now().minusYears(1);
-        List<DailySolveCount> dailySolveCounts = answerRepository.findDailySolveCountsByUserId(
+        List<Object[]> rawResults = answerRepository.findDailySolveCountsByUserId(
                 userId, forOneYear);
+
+        List<DailySolveCount> dailySolveCounts = rawResults.stream()
+                .map(row -> new DailySolveCount(
+                        ((Date) row[0]).toLocalDate(),
+                        ((Number) row[1]).longValue()
+                ))
+                .toList();
 
         return RivalProfileResponse.from(user, totalAnswerCount, dailySolveCounts);
     }


### PR DESCRIPTION
- RivalService : Object[] 결과를 DailySolveCount DTO로의 변환 로직 추가

# 🔄 Pull Request

## 📝 변경 사항
<!-- 변경된 내용을 자세히 설명해주세요 -->
- ``AnswerRepository``의 ``findDailySolveCountsByUserId``에서 JPQL CAST 대신 DATE() 함수 사용
- ``RivalService``에서  Object[] -> DailySolveCount 변환 처리
- ``RivalService``에서 Date를 LocalDate로, Number를 Long으로 타입 캐스팅

## 🎯 관련 이슈
<!-- 이 PR이 해결하는 이슈가 있다면 링크해주세요 -->
Closes #85 

## 📸 스크린샷
<!-- 필요하다면 스크린샷을 첨부해주세요 -->

## 📋 추가 정보
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->
- JPA 공부하다가 CAST 함수를 알게 되어 사용했는데, 
MySQL 호환성은 생각 못했네요. 죄송합니다.
Native Query로 수정 완료했습니다!