### PR TITLE
Refactor#106 ENUM 타입을 VARCHAR로 변경

### DIFF
--- a/dailyq/src/main/java/com/knuissant/dailyq/domain/feedbacks/Feedback.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/domain/feedbacks/Feedback.java
@@ -43,7 +43,7 @@ public class Feedback {
     private Answer answer;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 10)
+    @Column(nullable = false, columnDefinition = "VARCHAR(20)")
     private FeedbackStatus status;
 
     @Column(columnDefinition = "MEDIUMTEXT")

--- a/dailyq/src/main/java/com/knuissant/dailyq/domain/questions/Question.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/domain/questions/Question.java
@@ -39,7 +39,7 @@ public class Question {
     private Long id;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "question_type", nullable = false, length = 15)
+    @Column(name = "question_type", nullable = false, columnDefinition = "VARCHAR(20)")
     private QuestionType questionType;
 
     @Column(name = "question_text", columnDefinition = "MEDIUMTEXT", nullable = false)
@@ -56,9 +56,9 @@ public class Question {
 
     @ManyToMany(fetch = FetchType.LAZY)
     @JoinTable(
-        name = "question_jobs",
-        joinColumns = @JoinColumn(name = "question_id"),
-        inverseJoinColumns = @JoinColumn(name = "job_id")
+            name = "question_jobs",
+            joinColumns = @JoinColumn(name = "question_id"),
+            inverseJoinColumns = @JoinColumn(name = "job_id")
     )
     @Builder.Default
     private Set<Job> jobs = new LinkedHashSet<>();

--- a/dailyq/src/main/java/com/knuissant/dailyq/domain/users/User.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/domain/users/User.java
@@ -43,7 +43,7 @@ public class User {
     private String name;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 10)
+    @Column(nullable = false, columnDefinition = "VARCHAR(20)")
     private UserRole role;
 
     @Column(nullable = false)

--- a/dailyq/src/main/java/com/knuissant/dailyq/domain/users/UserFlowProgress.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/domain/users/UserFlowProgress.java
@@ -40,7 +40,7 @@ public class UserFlowProgress {
     private User user;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "next_phase", nullable = false, length = 15)
+    @Column(name = "next_phase", nullable = false, columnDefinition = "VARCHAR(20)")
     private FlowPhase nextPhase;
 
     @Column(name = "updated_at", nullable = false)

--- a/dailyq/src/main/java/com/knuissant/dailyq/domain/users/UserPreferences.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/domain/users/UserPreferences.java
@@ -45,11 +45,11 @@ public class UserPreferences {
     private Integer dailyQuestionLimit;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "question_mode", nullable = false, length = 10)
+    @Column(name = "question_mode", nullable = false, columnDefinition = "VARCHAR(20)")
     private QuestionMode questionMode;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "user_response_type", nullable = false, length = 10)
+    @Column(name = "user_response_type", nullable = false, columnDefinition = "VARCHAR(20)")
     private UserResponseType userResponseType;
 
     @Column(name = "time_limit_seconds")

--- a/dailyq/src/main/resources/static/01_schema.sql
+++ b/dailyq/src/main/resources/static/01_schema.sql
@@ -19,7 +19,7 @@ CREATE TABLE users (
                        user_id BIGINT PRIMARY KEY AUTO_INCREMENT,
                        email VARCHAR(255) NOT NULL UNIQUE,
                        name VARCHAR(100),
-                       role ENUM('FREE','PAID','ADMIN') NOT NULL DEFAULT 'FREE',
+                       role VARCHAR(20) NOT NULL DEFAULT 'FREE',
                        streak INT NOT NULL DEFAULT 0,
                        solved_today TINYINT(1) NOT NULL DEFAULT 0,
                        refresh_token VARCHAR(512) NULL,
@@ -53,8 +53,8 @@ CREATE TABLE jobs (
 CREATE TABLE user_preferences (
                              user_id BIGINT PRIMARY KEY,
                              daily_question_limit INT NOT NULL DEFAULT 1,
-                             question_mode ENUM('TECH','FLOW') NOT NULL DEFAULT 'TECH',
-                             user_response_type ENUM('VOICE','TEXT') NOT NULL DEFAULT 'TEXT',
+                             question_mode VARCHAR(20) NOT NULL DEFAULT 'TECH',
+                             user_response_type VARCHAR(20) NOT NULL DEFAULT 'TEXT',
                              time_limit_seconds INT DEFAULT 180,
                              notify_time TIME NULL,
                              allow_push TINYINT(1) NOT NULL DEFAULT 0,
@@ -71,7 +71,7 @@ CREATE TABLE user_preferences (
    ========================= */
 CREATE TABLE questions (
                            question_id BIGINT PRIMARY KEY AUTO_INCREMENT,
-                           question_type ENUM('TECH','INTRO','MOTIVATION','PERSONALITY') NOT NULL,
+                           question_type VARCHAR(20) NOT NULL,
                            question_text MEDIUMTEXT NOT NULL,
                            enabled TINYINT(1) NOT NULL DEFAULT 1,
                            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -98,7 +98,7 @@ CREATE TABLE question_jobs (
    ========================= */
 CREATE TABLE user_flow_progress (
                                     user_id BIGINT PRIMARY KEY,
-                                    next_phase ENUM('INTRO','MOTIVATION','TECH1','TECH2','PERSONALITY') NOT NULL DEFAULT 'INTRO',
+                                    next_phase VARCHAR(20) NOT NULL DEFAULT 'INTRO',
                                     updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
                                     CONSTRAINT fk_flow_progress_user
                                         FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
@@ -132,7 +132,7 @@ CREATE TABLE answers (
 CREATE TABLE feedbacks (
                            feedback_id BIGINT PRIMARY KEY AUTO_INCREMENT,
                            answer_id BIGINT NOT NULL,
-                           status ENUM('PENDING','DONE','FAILED') NOT NULL DEFAULT 'PENDING',
+                           status VARCHAR(20) NOT NULL DEFAULT 'PENDING',
                            content MEDIUMTEXT NULL, -- entity 생성 후
                            latency_ms BIGINT NULL, -- entity 생성 후, 지연 시간 측정 필요
                                created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/dailyq/src/main/resources/static/01_schema.sql
+++ b/dailyq/src/main/resources/static/01_schema.sql
@@ -21,7 +21,7 @@ CREATE TABLE users (
                        name VARCHAR(100),
                        role VARCHAR(20) NOT NULL DEFAULT 'FREE',
                        streak INT NOT NULL DEFAULT 0,
-                       solved_today TINYINT(1) NOT NULL DEFAULT 0,
+                       solved_today TINYINT NOT NULL DEFAULT 0,
                        refresh_token VARCHAR(512) NULL,
                        created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
                        updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
@@ -57,7 +57,7 @@ CREATE TABLE user_preferences (
                              user_response_type VARCHAR(20) NOT NULL DEFAULT 'TEXT',
                              time_limit_seconds INT DEFAULT 180,
                              notify_time TIME NULL,
-                             allow_push TINYINT(1) NOT NULL DEFAULT 0,
+                             allow_push TINYINT NOT NULL DEFAULT 0,
                              user_job BIGINT NOT NULL,
                              CONSTRAINT fk_user_prefs_user
                                  FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE,
@@ -73,7 +73,7 @@ CREATE TABLE questions (
                            question_id BIGINT PRIMARY KEY AUTO_INCREMENT,
                            question_type VARCHAR(20) NOT NULL,
                            question_text MEDIUMTEXT NOT NULL,
-                           enabled TINYINT(1) NOT NULL DEFAULT 1,
+                           enabled TINYINT NOT NULL DEFAULT 1,
                            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
                            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
                            CONSTRAINT uq_questions_text UNIQUE (question_text(255)),
@@ -114,7 +114,7 @@ CREATE TABLE answers (
                          question_id BIGINT NOT NULL,
                          answer_text MEDIUMTEXT NOT NULL, -- 오디오 변환 후 answer 생성
                          level TINYINT NULL,
-                         starred TINYINT(1) NOT NULL DEFAULT 0, -- default 0
+                         starred TINYINT NOT NULL DEFAULT 0, -- default 0
                          created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
                          memo MEDIUMTEXT NULL, -- 메모 필드 추가
                          CONSTRAINT ck_answers_level CHECK (level IS NULL OR (level BETWEEN 1 AND 5)),


### PR DESCRIPTION
# 🔄 Pull Request

## 📝 변경 사항
<!-- 변경된 내용을 자세히 설명해주세요 -->
- 기존 ENUM 타입으로 관리되던 상태/타입 컬럼들을 VARCHAR(20) 타입으로 통일 및 적용
  - 기존(ENUM): 새로운 값 추가 시 DB 스키마 변경이 필수적이어서 유연성이 떨어짐
  - 현재(VARCHAR): 스키마 변경 없이 애플리케이션 코드 수정만으로 상태 추가 가능
  - 추후 확장성을 위해 length는 20으로 지정 후 모든 컬럼에 length 통일
- 추가로 mysql 8.0에서 정수형 데이터 타입에 표시 너비를 지정하는 것이 더 이상 사용되지 않는다는 warning에 따라 TINYINT의 너비 지정 제거
 
## 🎯 관련 이슈
<!-- 이 PR이 해결하는 이슈가 있다면 링크해주세요 -->
Closes #106 

## 📸 스크린샷
<!-- 필요하다면 스크린샷을 첨부해주세요 -->

## 📋 추가 정보
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->
- schema.sql 변경되었습니다. 머지 후 테크스펙에도 수정해두겠습니다!