### PR TITLE
fix : 서버 메모리 용량 초과로 인해 prometheus, grafana 비활성화

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,55 +91,8 @@ services:
       retries: 6
       start_period: 150s
 
-  prometheus:
-    image: prom/prometheus:latest
-    container_name: dailyq-prometheus
-    restart: unless-stopped # 서버 자동 재부팅
-    ports:
-      - "127.0.0.1:9090:9090" # 외부는 반드시 서버에서 접속
-    volumes:
-      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
-      - prometheus_data:/prometheus
-    command:
-      - '--config.file=/etc/prometheus/prometheus.yml'
-    deploy:
-      resources:
-        limits:
-          cpus: '0.5'
-          memory: 512M
-        reservations:
-          cpus: '0.25'
-          memory: 256M
-    networks:
-      - dailyq-network
-    depends_on:
-      app: #app service가 먼저 실행
-        condition: service_healthy
-  grafana:
-    image: grafana/grafana:latest
-    container_name: dailyq-grafana
-    restart: unless-stopped
-    ports:
-      - "127.0.0.1:3000:3000" # 표준
-    volumes:
-      - grafana_data:/var/lib/grafana
-    deploy:
-      resources:
-        limits:
-          cpus: '0.5'
-          memory: 512M
-        reservations:
-          cpus: '0.25'
-          memory: 256M
-    networks:
-      - dailyq-network
-    depends_on:
-      - prometheus
-
 volumes:
   mysql_data:
-  prometheus_data:
-  grafana_data:
 
 networks:
   dailyq-network:


### PR DESCRIPTION
# 🔄 Pull Request

## 📝 변경 사항
<!-- 변경된 내용을 자세히 설명해주세요 -->
- 서버 메모리 용량 초과로 인해 docker-compose 파일 수정 (prometheus, grafana 비활성화)

## 🎯 관련 이슈
<!-- 이 PR이 해결하는 이슈가 있다면 링크해주세요 -->
* Closes #171 

## 📸 스크린샷
<!-- 필요하다면 스크린샷을 첨부해주세요 -->

## 📋 추가 정보
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 배포 인프라 간소화: 모니터링 솔루션인 Prometheus 및 Grafana 서비스와 관련 데이터 저장소가 배포 구성에서 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->