### PR TITLE
fix: SSE 연결 요청 시, 쿼리 파라미터에서 토큰 추출

### DIFF
--- a/dailyq/src/main/java/com/knuissant/dailyq/controller/SseController.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/controller/SseController.java
@@ -11,7 +11,9 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import lombok.RequiredArgsConstructor;
 
+import com.knuissant.dailyq.dto.sse.SseTokenResponse;
 import com.knuissant.dailyq.service.SseService;
+import com.knuissant.dailyq.service.TokenService;
 
 @RestController
 @RequestMapping("/api/sse")
@@ -19,6 +21,15 @@ import com.knuissant.dailyq.service.SseService;
 public class SseController {
 
     private final SseService sseService;
+    private final TokenService tokenService;
+
+    @GetMapping("/token")
+    public ResponseEntity<SseTokenResponse> getSseToken(@AuthenticationPrincipal User principal) {
+        Long userId = Long.parseLong(principal.getUsername());
+
+        return ResponseEntity.ok(new SseTokenResponse(tokenService.generateSseToken(userId)));
+    }
+
 
     @GetMapping(path = "/connect", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public ResponseEntity<SseEmitter> connectSse(@AuthenticationPrincipal User principal) {

--- a/dailyq/src/main/java/com/knuissant/dailyq/dto/sse/SseTokenResponse.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/dto/sse/SseTokenResponse.java
@@ -1,0 +1,7 @@
+package com.knuissant.dailyq.dto.sse;
+
+public record SseTokenResponse(
+        String sseToken
+) {
+
+}

--- a/dailyq/src/main/java/com/knuissant/dailyq/service/TokenService.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/service/TokenService.java
@@ -53,5 +53,14 @@ public class TokenService {
         // --- 모든 검증 통과: 새로운 Access Token 생성 ---
         return tokenProvider.generateAccessToken(user);
     }
+
+    @Transactional(readOnly = true)
+    public String generateSseToken(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND, userId));
+        
+        return tokenProvider.generateSseToken(user);
+    }
+
 }
 


### PR DESCRIPTION
# 🔄 Pull Request

## 📝 변경 사항
<!-- 변경된 내용을 자세히 설명해주세요 -->
- 프론트엔드가 SSE 연결에 사용하는 자바스크립트 기술(EventSource API)은 보안상의 한계로 Authorization 같은 커스텀 헤더를 설정하는 기능을 지원하지 않아 SSE 연결 시 토큰을 헤더에 전송하지 않음 -> Spring Security 통과하지 못함
- 프론트엔드에서는 SSE를 연결할 때, URL의 쿼리 파라미터로 토큰을 보내야 함
- 이에 따라, Spring Security의 `jwtAuthenticationFilter`에 SSE 연결 시, 헤더가 아닌 쿼리 파라미터에서 토큰을 추출하도록 규칙 추가

## 🎯 관련 이슈
<!-- 이 PR이 해결하는 이슈가 있다면 링크해주세요 -->
* Closes #180

## 📸 스크린샷
<!-- 필요하다면 스크린샷을 첨부해주세요 -->

## 📋 추가 정보
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 서버 전송 이벤트(SSE)용 토큰을 발급받는 새 엔드포인트가 추가되어, 인증된 사용자로부터 SSE 전용 토큰을 받을 수 있습니다.
  * /api/sse/connect 연결 시 쿼리 파라미터(token)로부터 인증 토큰을 읽어오는 방식이 지원되어 기존 Authorization 헤더와 함께 유연한 인증이 가능합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->