### PR TITLE
fix : 아카이브 꼬리질문 조회 불가능 문제 해결

### DIFF
--- a/dailyq/src/main/java/com/knuissant/dailyq/dto/answers/AnswerListResponse.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/dto/answers/AnswerListResponse.java
@@ -14,23 +14,38 @@ public record AnswerListResponse(List<Summary> summaries) {
             Long questionId,
             String questionText,
             QuestionType questionType,
-            FlowPhase flowPhase,
             Integer level,
             Boolean starred,
-            LocalDateTime createdAt
+            LocalDateTime createdAt,
+            Boolean isFollowup
     ) {
 
         public static Summary from(Answer answer) {
-            return new Summary(
-                    answer.getId(),
-                    answer.getQuestion().getId(),
-                    answer.getQuestion().getQuestionText(),
-                    answer.getQuestion().getQuestionType(),
-                    null, // flow_phase는 FE와 협의 필요
-                    answer.getLevel(),
-                    answer.getStarred(),
-                    answer.getCreatedAt()
-            );
+            boolean isFollowUp = answer.getFollowUpQuestion() != null;
+
+            if (isFollowUp) {
+                return new Summary(
+                        answer.getId(),
+                        answer.getFollowUpQuestion().getId(),
+                        answer.getFollowUpQuestion().getQuestionText(),
+                        QuestionType.TECH,
+                        answer.getLevel(),
+                        answer.getStarred(),
+                        answer.getCreatedAt(),
+                        true
+                );
+            } else {
+                return new Summary(
+                        answer.getId(),
+                        answer.getQuestion().getId(),
+                        answer.getQuestion().getQuestionText(),
+                        answer.getQuestion().getQuestionType(),
+                        answer.getLevel(),
+                        answer.getStarred(),
+                        answer.getCreatedAt(),
+                        false
+                );
+            }
         }
     }
 


### PR DESCRIPTION
- answer 엔티티의 followUpQuestion 활용

# 🔄 Pull Request

## 📝 변경 사항
<!-- 변경된 내용을 자세히 설명해주세요 -->
- 꼬리질문과 일반질문은 다른 table에 존재하도록 설계되었으나 현재는 구분하지 못하는 문제
- 아카이브 꼬리질문 조회 불가능 문제 해결

## 🎯 관련 이슈
<!-- 이 PR이 해결하는 이슈가 있다면 링크해주세요 -->
* Closes #186 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 답변 응답에서 후속 질문에 대한 구분 기능 추가
  * 후속 질문 여부를 나타내는 새로운 표시자 적용
  * 답변 리스트의 정보 구조 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->