### PR TITLE
Refactor#185 피드백 요청 응답에 꼬리질문 여부 추가

### DIFF
--- a/dailyq/src/main/java/com/knuissant/dailyq/controller/FeedbackController.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/controller/FeedbackController.java
@@ -1,6 +1,8 @@
 package com.knuissant.dailyq.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -10,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 
 import com.knuissant.dailyq.dto.feedbacks.FeedbackResponse;
 import com.knuissant.dailyq.service.FeedbackService;
+
 @RestController
 @RequestMapping("/api/feedback")
 @RequiredArgsConstructor
@@ -18,7 +21,16 @@ public class FeedbackController {
     private final FeedbackService feedbackService;
 
     @GetMapping("/{feedbackId}")
-    public ResponseEntity<FeedbackResponse> getFeedback(@PathVariable Long feedbackId) {
-        return ResponseEntity.ok(feedbackService.generateFeedback(feedbackId));
+    public ResponseEntity<FeedbackResponse> getFeedback(
+            @AuthenticationPrincipal User principal,
+            @PathVariable Long feedbackId) {
+
+        Long userId = getUserId(principal);
+
+        return ResponseEntity.ok(feedbackService.generateFeedback(userId, feedbackId));
+    }
+
+    private Long getUserId(User principal) {
+        return Long.parseLong(principal.getUsername());
     }
 }

--- a/dailyq/src/main/java/com/knuissant/dailyq/dto/answers/AnswerCreateRequest.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/dto/answers/AnswerCreateRequest.java
@@ -15,10 +15,13 @@ public record AnswerCreateRequest(
         boolean followUp
 ) {
 
-    @AssertTrue(message = "answerText 또는 audioUrl 중 하나는 반드시 존재해야 합니다.")
+    @AssertTrue(message = "answerText 또는 audioUrl 중 정확히 하나만 존재해야 합니다.")
     @JsonIgnore
     public boolean isContentPresent() {
-        return StringUtils.hasText(answerText) || StringUtils.hasText(audioUrl);
+        boolean isTextPresent = StringUtils.hasText(answerText);
+        boolean isAudioPresent = StringUtils.hasText(audioUrl);
+
+        return (isTextPresent && !isAudioPresent) || (!isTextPresent && isAudioPresent);
     }
 
 }

--- a/dailyq/src/main/java/com/knuissant/dailyq/dto/answers/AnswerDetailResponse.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/dto/answers/AnswerDetailResponse.java
@@ -40,7 +40,7 @@ public record AnswerDetailResponse(
                 answer.getLevel(),
                 answer.getStarred(),
                 answer.getCreatedAt(),
-                (feedback != null) ? FeedbackResponse.from(feedback) : null
+                (feedback != null) ? FeedbackResponse.of(feedback, answer.getFollowUpQuestion() != null) : null
         );
     }
 }

--- a/dailyq/src/main/java/com/knuissant/dailyq/dto/answers/AnswerListResponse.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/dto/answers/AnswerListResponse.java
@@ -4,7 +4,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import com.knuissant.dailyq.domain.answers.Answer;
-import com.knuissant.dailyq.domain.questions.FlowPhase;
 import com.knuissant.dailyq.domain.questions.QuestionType;
 
 public record AnswerListResponse(List<Summary> summaries) {

--- a/dailyq/src/main/java/com/knuissant/dailyq/dto/feedbacks/FeedbackResponse.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/dto/feedbacks/FeedbackResponse.java
@@ -9,14 +9,16 @@ import com.knuissant.dailyq.domain.feedbacks.FeedbackStatus;
 public record FeedbackResponse(
         FeedbackStatus status,
         FeedbackContent content,
-        LocalDateTime updatedAt
+        LocalDateTime updatedAt,
+        boolean followUp
 ) {
 
-    public static FeedbackResponse from(Feedback feedback) {
+    public static FeedbackResponse of(Feedback feedback, boolean followUp) {
         return new FeedbackResponse(
                 feedback.getStatus(),
                 feedback.getContent(),
-                feedback.getUpdatedAt()
+                feedback.getUpdatedAt(),
+                followUp
         );
     }
 }

--- a/dailyq/src/main/java/com/knuissant/dailyq/repository/FeedbackRepository.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/repository/FeedbackRepository.java
@@ -18,7 +18,7 @@ public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
 
     Optional<Feedback> findByAnswerId(Long answerId);
 
-    @EntityGraph(attributePaths = {"answer", "answer.question"})
+    @EntityGraph(attributePaths = {"answer", "answer.question", "answer.followUpQuestion"})
     Optional<Feedback> findWithDetailsById(Long id);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/dailyq/src/main/java/com/knuissant/dailyq/service/FeedbackService.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/service/FeedbackService.java
@@ -35,10 +35,12 @@ public class FeedbackService {
         return feedbackRepository.save(feedback);
     }
 
-    public FeedbackResponse generateFeedback(Long feedbackId) {
+    public FeedbackResponse generateFeedback(Long userId, Long feedbackId) {
 
         Feedback feedback = feedbackRepository.findWithDetailsById(feedbackId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.FEEDBACK_NOT_FOUND, feedbackId));
+
+        feedback.getAnswer().checkOwnership(userId);
 
         boolean followUp = (feedback.getAnswer() != null && feedback.getAnswer().getFollowUpQuestion() != null);
 

--- a/dailyq/src/main/java/com/knuissant/dailyq/service/FeedbackService.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/service/FeedbackService.java
@@ -40,8 +40,10 @@ public class FeedbackService {
         Feedback feedback = feedbackRepository.findWithDetailsById(feedbackId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.FEEDBACK_NOT_FOUND, feedbackId));
 
+        boolean followUp = (feedback.getAnswer() != null && feedback.getAnswer().getFollowUpQuestion() != null);
+
         if (feedback.isDone()) {
-            return FeedbackResponse.from(feedback);
+            return FeedbackResponse.of(feedback, followUp);
         }
 
         feedbackUpdateService.changeStatusToProcessing(feedbackId);
@@ -59,7 +61,7 @@ public class FeedbackService {
 
             Feedback updatedFeedback = feedbackUpdateService.updateFeedbackSuccess(feedbackId, feedbackContent, latencyMs);
 
-            return FeedbackResponse.from(updatedFeedback);
+            return FeedbackResponse.of(updatedFeedback, followUp);
 
         } catch (Exception e) {
             try {


### PR DESCRIPTION
# 🔄 Pull Request

## 📝 변경 사항
<!-- 변경된 내용을 자세히 설명해주세요 -->
- FeedbackResponse에 꼬리질문 여부 추가
- getFeedback 요청 시, 소유권 확인 로직 추가
- AnswerCreateRequest에서 text와 audioUrl 중 하나만 제출할 수 있도록 제한

## 🎯 관련 이슈
<!-- 이 PR이 해결하는 이슈가 있다면 링크해주세요 -->
* Closes #185

## 📸 스크린샷
<!-- 필요하다면 스크린샷을 첨부해주세요 -->

## 📋 추가 정보
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 피드백 조회 시 사용자 인증 필요
  * 응답에 후속 질문 정보 표시

* **버그 수정**
  * 응답 생성 검증 강화 (텍스트 또는 오디오 중 정확히 하나만 선택 가능)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->