### PR TITLE
fix: SSE 비동기(ASYNC) 요청에 대한 불필요한 인가 오류 수정

### DIFF
--- a/dailyq/src/main/java/com/knuissant/dailyq/config/SecurityConfig.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/config/SecurityConfig.java
@@ -3,6 +3,8 @@ package com.knuissant.dailyq.config;
 import java.util.Arrays;
 import java.util.List;
 
+import jakarta.servlet.DispatcherType;
+
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -50,6 +52,10 @@ public class SecurityConfig {
                         session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 // HTTP 요청에 대한 접근 권한 설정
                 .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers(request ->
+                                request.getDispatcherType() == DispatcherType.ASYNC &&
+                                        request.getRequestURI().equals("/api/sse/connect")
+                        ).permitAll()
                         //preflight 처리를 위해 OPTIONS Method 허용
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers("/actuator/**").permitAll()


### PR DESCRIPTION
# 🔄 Pull Request

## 📝 변경 사항
<!-- 변경된 내용을 자세히 설명해주세요 -->
- SSE 연결 시 발생하는 Access Denied 로그를 해결하기 위해 Spring Security 설정 수정
- 원인: SSE 연결 유지를 위한 ASYNC 내부 디스패치가 재인증을 시도하며 발생하는 충돌
- 해결: Security Filter Chain에서 ASYNC Dispatch 타입의 요청은 보안 검사를 허용하도록 설정

## 🎯 관련 이슈
<!-- 이 PR이 해결하는 이슈가 있다면 링크해주세요 -->
* Closes #184 

## 📸 스크린샷
<!-- 필요하다면 스크린샷을 첨부해주세요 -->

## 📋 추가 정보
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 서버-클라이언트 간 실시간 데이터 동기화 기능이 활성화되었습니다. 비동기 요청에 대한 인증 처리가 개선되었으며, 사용자는 이제 즉각적인 서버 업데이트를 받을 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->