### PR TITLE
fix : 아카이브 꼬리질문 상세조회 불가능 문제 해결

### DIFF
--- a/dailyq/src/main/java/com/knuissant/dailyq/dto/answers/AnswerDetailResponse.java
+++ b/dailyq/src/main/java/com/knuissant/dailyq/dto/answers/AnswerDetailResponse.java
@@ -32,9 +32,19 @@ public record AnswerDetailResponse(
     }
 
     public static AnswerDetailResponse of(Answer answer, Feedback feedback) {
+        boolean isFollowUp = answer.getFollowUpQuestion() != null;
+
+        QuestionSummary questionSummary = isFollowUp
+                ? new QuestionSummary(
+                answer.getFollowUpQuestion().getId(),
+                QuestionType.TECH,
+                answer.getFollowUpQuestion().getQuestionText()
+        )
+                : QuestionSummary.from(answer.getQuestion());
+
         return new AnswerDetailResponse(
                 answer.getId(),
-                QuestionSummary.from(answer.getQuestion()),
+                questionSummary,
                 answer.getAnswerText(),
                 answer.getMemo(),
                 answer.getLevel(),


### PR DESCRIPTION
- answer 엔티티의 followUpQuestion 활용

# 🔄 Pull Request

## 📝 변경 사항
<!-- 변경된 내용을 자세히 설명해주세요 -->
- 아카이브 꼬리질문 상세조회 불가능 문제 해결

## 🎯 관련 이슈
<!-- 이 PR이 해결하는 이슈가 있다면 링크해주세요 -->
* Closes #190 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* 팔로우업 질문이 있는 답변의 상세 정보에서 질문 표시 방식이 개선되었습니다.
* 팔로우업 질문이 존재할 때 이를 올바르게 반영하도록 로직이 조정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->